### PR TITLE
Numerical gradient check, remove vocab as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 python:
   - 2.7
 script:
-  - export PATH=$HOME/py/bin:$PATH
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source activate test-environment
   - make test
 cache:
   - apt

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ with asynchronous stochastic gradient descent (Adagrad).
 ## Getting started
 
 ### Installing
-First install numpy, scipy and the packages in `requirements.txt`.
-Then `sudo make install`.  `make test` runs the test suite.
+1.  Install the dependencies: numpy, scipy, the packages in `requirements.txt`
+and [`vocab`](http://github.com/seomoz/vocab).  The Travis CI provisioning
+script installs these packages [`provision.sh`](provision.sh) and may be useful
+as a starting point.
+
+2.  Build/install `word2gauss`: `sudo make install`
+
+3.  Finally it's a good idea to run the test suite: `make test` 
 
 NOTE: The performance sensitive parts of the code have been carefully
 written in a way that allows gcc to auto-vectorize all the important loops.
@@ -44,23 +50,18 @@ no knowledge of any vocabulary and operates only on
 unique IDs.  Each ID is a `uint32` from `0 .. N-1` with `-1` signifying
 an OOV token.
 
-For learning word embeddings, the token - id mapping is off-loaded to a
+For learning word embeddings, the token - id mapping is off-loaded to
+the [`vocab`](http://github.com/seomoz/vocab) repository.  This provides a
 `Vocabulary` class that translates streams of documents into `token_id` lists
 and provides the ability to draw a random `token_id` from the
 token distribution.  The random generator is necessary for the negative
 sampling needed to generate training positive/negative training pairs from a
-sentence (see details below).  We assume the `Vocabulary` has these methods:
-
-* `tokenize(text)` returns a numpy array of token IDs in the text or -1 for OOV tokens
-* `random_ids(N)` returns a length N numpy array of random IDs
-* `word2id(string)` and `id2word(uint32)` map from string <-> id
-* `__len__(self)` returns number of words in vocabulary
+sentence (see details below).
 
 
 ### Learning embeddings
 
-To learn embeddings, you will need a suitable corpus and an implementation
-of the `Vocabulary` interface.
+To learn embeddings, you will need a suitable corpus.
 
 ```python
 import logging
@@ -141,7 +142,7 @@ and optimize the parameters to minimize the sum of the loss over
 the entire training set of positive/negative pairs.
 
 To generate the training pairs, use co-occuring words as the positive
-examples and a randomly sampled words as the negative examples.
+examples and randomly sampled words as the negative examples.
 Since the energy function is potentially asymmetric, for each co-occuring
 word pair randomly sample both the left and right tokens for negative
 examples.  In addition, we allow the option to generate several

--- a/provision.sh
+++ b/provision.sh
@@ -23,14 +23,6 @@ source activate test-environment
 # other dependencies
 pip install -r requirements.txt
 
-mkdir ~/git
-pushd ~/git
-git clone https://github.com/seomoz/vocab.git
-pushd ~/git/vocab
-pip install -r requirements.txt
-python setup.py install
-popd; popd
-
 # finally our build
 python setup.py build_ext --inplace
 

--- a/provision.sh
+++ b/provision.sh
@@ -11,10 +11,6 @@ pip install -r requirements.txt
 python setup.py build_ext --inplace
 export PATH=$HOME/py/bin:$PATH
 
-echo 'Host github.com
-  StrictHostKeyChecking no
-' >> ~/.ssh/config
-
 mkdir ~/git
 (
     cd ~/git
@@ -25,4 +21,5 @@ mkdir ~/git
         python setup.py install
     )
 )
+
 

--- a/provision.sh
+++ b/provision.sh
@@ -4,22 +4,33 @@ set -e
 sudo apt-get update
 
 sudo apt-get -y install libatlas-base-dev libatlas-dev lib{blas,lapack}-dev gfortran
-sudo pip install conda
+# install conda, see http://conda.pydata.org/docs/travis.html
+if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+else
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+fi
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
 conda_deps='pip numpy scipy'
-conda create -p $HOME/py --yes $conda_deps "python=$TRAVIS_PYTHON_VERSION"
+conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $conda_deps
+source activate test-environment
+
+# other dependencies
 pip install -r requirements.txt
-python setup.py build_ext --inplace
-export PATH=$HOME/py/bin:$PATH
 
 mkdir ~/git
-(
-    cd ~/git
-    git clone https://github.com/seomoz/vocab.git
-    (
-        cd ~/git/vocab
-        pip install -r requirements.txt
-        python setup.py install
-    )
-)
+pushd ~/git
+git clone https://github.com/seomoz/vocab.git
+pushd ~/git/vocab
+pip install -r requirements.txt
+python setup.py install
+popd; popd
 
+# finally our build
+python setup.py build_ext --inplace
 

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -133,6 +133,71 @@ class TestIPEnergy(unittest.TestCase):
         actual = embed.energy(1, 2)
         self.assertAlmostEqual(actual, expected, places=6)
 
+def numerical_grad(embed, i, j, eps=1.0e-3):
+    '''
+    Computes gradient and numerical gradient
+
+    returns [(grad mu, numerical grad mu), (grad sigma), (num. grad sigma)]
+    '''
+    from word2gauss.embeddings import COV_MAP
+
+    # compute the gradient at i, j
+    (dmui, dsigmai), (dmuj, dsigmaj) = embed.gradient(i, j)
+    dmu = [dmui, dmuj]
+    dsigma = [dsigmai, dsigmaj]
+
+    # now compute numerical gradient
+    Eij = embed.energy(i, j)
+
+    ndmu = [np.zeros(dmui.shape), np.zeros(dmuj.shape)]
+    ndsigma = [np.zeros(dsigmai.shape), np.zeros(dsigmaj.shape)]
+    
+    for ind, ij in enumerate([i, j]):
+        for k in xrange(embed.K):
+            embed.mu[ij, k] += eps
+            E = embed.energy(i, j)
+            ndmu[ind][k] = (E - Eij) / eps
+            embed.mu[ij, k] -= eps
+
+            if COV_MAP[embed.covariance_type] == 'diagonal':
+                embed.sigma[ij, k] += eps
+                E = embed.energy(i, j)
+                ndsigma[ind][k] = (E - Eij) / eps
+                embed.sigma[ij, k] -= eps
+
+        #if COV_MAP[embed.covariance_type] == 'spherical':
+        #    embed.sigma[ij] += eps
+        #    E = embed.energy(i, j)
+        #    ndsigma[ind] = (E - Eij) / eps
+        #    embed.sigma[ij] -= eps
+
+
+    return [(dmu, ndmu), (dsigma, ndsigma)]
+
+
+class TestNumericalGradient(unittest.TestCase):
+    def _num_grad_check(self, embed, eps, rtol):
+        [(dmu, ndmu), (dsigma, ndsigma)] = numerical_grad(embed, 0, 1, eps)
+        for ij in [0, 1]:
+            self.assertTrue(
+                np.allclose(dmu[ij], ndmu[ij], rtol=rtol))
+            self.assertTrue(
+                np.allclose(dsigma[ij], ndsigma[ij], rtol=rtol))
+
+    def test_numerical_grad_kl(self):
+        #embed = sample_embed('KL', 'spherical')
+        #self._num_grad_check(embed)
+
+        embed = sample_embed('KL', 'diagonal')
+        self._num_grad_check(embed, 1.0e-3, 1e-01)
+
+    def test_numerical_grad_ip(self):
+        #embed = sample_embed('IP', 'spherical')
+        #self._num_grad_check(embed, 1.0e-6, 1e-1)
+
+        embed = sample_embed('IP', 'diagonal')
+        self._num_grad_check(embed, 1.0e-3, 1e-01)
+
 
 class TestGaussianEmbedding(unittest.TestCase):
     def _training_data(self):

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -3,13 +3,13 @@ import unittest
 import numpy as np
 import numpy.testing as test
 from word2gauss.embeddings import GaussianEmbedding, text_to_pairs
-from vocab import Vocabulary
+from word2gauss.words import Vocabulary
 
 DTYPE = np.float32
 
 def sample_vocab():
-    ngrams = [{'new':0, 'york':1, 'city':2}]
-    vocab = Vocabulary(ngrams)
+    tokens = {'new':0, 'york':1, 'city':2}
+    vocab = Vocabulary(tokens)
     return vocab
 
 

--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 import numpy.testing as test
 from word2gauss.embeddings import GaussianEmbedding, text_to_pairs
-#import vocab as v
 from vocab import Vocabulary
 
 DTYPE = np.float32
@@ -12,6 +11,7 @@ def sample_vocab():
     ngrams = [{'new':0, 'york':1, 'city':2}]
     vocab = Vocabulary(ngrams)
     return vocab
+
 
 def sample_embed(energy_type='KL', covariance_type='spherical', eta=0.1):
     mu = np.array([
@@ -165,11 +165,11 @@ def numerical_grad(embed, i, j, eps=1.0e-3):
                 ndsigma[ind][k] = (E - Eij) / eps
                 embed.sigma[ij, k] -= eps
 
-        #if COV_MAP[embed.covariance_type] == 'spherical':
-        #    embed.sigma[ij] += eps
-        #    E = embed.energy(i, j)
-        #    ndsigma[ind] = (E - Eij) / eps
-        #    embed.sigma[ij] -= eps
+        if COV_MAP[embed.covariance_type] == 'spherical':
+            embed.sigma[ij] += eps
+            E = embed.energy(i, j)
+            ndsigma[ind] = (E - Eij) / eps
+            embed.sigma[ij] -= eps
 
 
     return [(dmu, ndmu), (dsigma, ndsigma)]
@@ -185,18 +185,18 @@ class TestNumericalGradient(unittest.TestCase):
                 np.allclose(dsigma[ij], ndsigma[ij], rtol=rtol))
 
     def test_numerical_grad_kl(self):
-        #embed = sample_embed('KL', 'spherical')
-        #self._num_grad_check(embed)
+        embed = sample_embed('KL', 'spherical')
+        self._num_grad_check(embed, 1.0e-3, 1e-1)
 
         embed = sample_embed('KL', 'diagonal')
-        self._num_grad_check(embed, 1.0e-3, 1e-01)
+        self._num_grad_check(embed, 1.0e-3, 1e-1)
 
     def test_numerical_grad_ip(self):
-        #embed = sample_embed('IP', 'spherical')
-        #self._num_grad_check(embed, 1.0e-6, 1e-1)
+        embed = sample_embed('IP', 'spherical')
+        self._num_grad_check(embed, 1.0e-3, 1e-1)
 
         embed = sample_embed('IP', 'diagonal')
-        self._num_grad_check(embed, 1.0e-3, 1e-01)
+        self._num_grad_check(embed, 1.0e-3, 1e-1)
 
 
 class TestGaussianEmbedding(unittest.TestCase):

--- a/test/test_words.py
+++ b/test/test_words.py
@@ -1,0 +1,35 @@
+
+import unittest
+import numpy as np
+import numpy.testing as test
+from word2gauss.words import Vocabulary, iter_pairs
+
+DTYPE = np.float32
+
+class TestIterPairs(unittest.TestCase):
+    def test_iter_pairs(self):
+        np.random.seed(1234)
+        vocab = Vocabulary({'zero': 0, 'one': 1, 'two': 2})
+
+        actual = list(iter_pairs(['zero one two', 'one two zero'],
+            vocab, batch_size=2, nsamples=1))
+        expected = np.array([[0, 1, 0, 2, 0],
+                            [0, 1, 1, 1, 1],
+                            [0, 2, 0, 0, 0],
+                            [0, 2, 0, 2, 1],
+                            [1, 2, 1, 0, 0],
+                            [1, 2, 1, 2, 1],
+                            [1, 2, 1, 1, 0],
+                            [1, 2, 1, 2, 1],
+                            [1, 0, 1, 2, 0],
+                            [1, 0, 2, 0, 1],
+                            [2, 0, 2, 2, 0],
+                            [2, 0, 0, 0, 1]], dtype=DTYPE)
+        self.assertEqual(len(actual), 1)
+        self.assertTrue(np.all(actual[0] == expected))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/word2gauss/embeddings.pyx
+++ b/word2gauss/embeddings.pyx
@@ -964,8 +964,7 @@ cdef void kl_gradient(size_t i, size_t j, size_t center_index,
         # Note:
         # Delta'[i, j] * Delta'[i, j].T is a dense K x K matrix, but we
         # only have one parameter that is tied along the diagonal.
-        # so, use the average of the diagnonal elements of the full
-        # matrix -- this amounts to the average of deltaprime ** 2
+        # so, use the diagnonal elements of the full matrix
         sum_deltaprime2 = 0.0
         one_over_si = 1.0 / sigmai_ptr[0]
         for k in xrange(K):
@@ -975,11 +974,11 @@ cdef void kl_gradient(size_t i, size_t j, size_t center_index,
             sum_deltaprime2 += deltaprime * deltaprime
 
         dEdsigmai_ptr[0] = 0.5 * (
-            sigma_ptr[j] * (1.0 / sigmai_ptr[0]) ** 2
-            + sum_deltaprime2 / K
-            - (1.0 / sigmai_ptr[0])
+            K * sigma_ptr[j] * (1.0 / sigmai_ptr[0]) ** 2
+            + sum_deltaprime2
+            - (K / sigmai_ptr[0])
         )
-        dEdsigmaj_ptr[0] = 0.5 * (1.0 / sigmaj_ptr[0] - 1.0 / sigmai_ptr[0])
+        dEdsigmaj_ptr[0] = 0.5 * (1.0 / sigmaj_ptr[0] - 1.0 / sigmai_ptr[0]) * K
 
     elif covariance_type == DIAGONAL:
         for k in xrange(K):
@@ -1119,8 +1118,8 @@ cdef void ip_gradient(size_t i, size_t j, size_t center_index,
             sum_delta2 += delta * delta
 
         dEdsigmai_ptr[0] = 0.5 * (
-            + sum_delta2 / K
-            - sigmai_plus_sigmaj_inv
+            + sum_delta2
+            - sigmai_plus_sigmaj_inv * K
         )
         dEdsigmaj_ptr[0] = dEdsigmai_ptr[0]
 

--- a/word2gauss/embeddings.pyx
+++ b/word2gauss/embeddings.pyx
@@ -60,6 +60,7 @@ LOGGER = logging.getLogger()
 
 cdef extern from "stdint.h":
     ctypedef unsigned long long uint32_t
+cdef uint32_t UINT32_MAX = 4294967295
 
 # type of our floating point arrays
 cdef type DTYPE = np.float32
@@ -1329,7 +1330,7 @@ cpdef np.ndarray[uint32_t, ndim=2, mode='c'] text_to_pairs(
 
     text is a list of text documents / sentences.
 
-    Each element of the list is a numpy array of uint32_t IDs, with 4294967295
+    Each element of the list is a numpy array of uint32_t IDs, with UINT32_MAX 
     signifying an OOV ID representing the document or sentence.
 
     For position k in the document, uses all contexts from k - half_window_size
@@ -1363,11 +1364,11 @@ cpdef np.ndarray[uint32_t, ndim=2, mode='c'] text_to_pairs(
         cdoc = doc
         doc_len = cdoc.shape[0]
         for i in range(doc_len):
-            if cdoc[i] == 4294967295:
+            if cdoc[i] == UINT32_MAX:
                 # OOV word
                 continue
             for j in range(i + 1, min(i + half_window_size + 1, doc_len)):
-                if cdoc[j] == 4294967295:
+                if cdoc[j] == UINT32_MAX:
                     # OOV word
                     continue
                 # take nsamples_per_word samples

--- a/word2gauss/words.py
+++ b/word2gauss/words.py
@@ -1,7 +1,76 @@
 
 from itertools import islice
 
+import numpy as np
+
 from .embeddings import text_to_pairs
+
+LARGEST_UINT32 = 4294967295
+
+def tokenizer(s):
+    '''
+    Whitespace tokenizer
+    '''
+    return s.strip().split()
+
+class Vocabulary(object):
+    '''
+    Implemetation of the Vocabulary interface
+
+    .word2id: given a token, return the id or raise KeyError if not in the vocab
+    .id2word: given a token id, return the token or raise IndexError if invalid
+    .tokenize: given a string, tokenize it using the tokenizer and then
+    remove all OOV tokens
+    .tokenize_ids: given a string, tokenize and return the token ids
+    .random_ids: given an integer, return a numpy array of random token ids
+    '''
+
+
+    def __init__(self, tokens, tokenizer=tokenizer):
+        '''
+        tokens: a {'token1': 0, 'token2': 1, ...} map of token -> id
+            the ids must run from 0 to n_tokens - 1 inclusive
+        tokenizer: accepts a string and returns a list of strings
+        '''
+        self._tokens = tokens
+        self._ids = {i: token for token, i in tokens.items()}
+        self._ntokens = len(tokens)
+        self._tokenizer = tokenizer
+
+    def word2id(self, word):
+        return self._tokens[word]
+
+    def id2word(self, i):
+        try:
+            return self._ids[i]
+        except KeyError:
+            raise IndexError
+
+    def tokenize(self, s):
+        '''
+        Removes OOV tokens using built 
+        '''
+        tokens = self._tokenizer(s)
+        return [token for token in tokens if token in self._tokens]
+
+    def tokenize_ids(self, s, remove_oov=True):
+        tokens = self._tokenizer(s)
+        if remove_oov:
+            return np.array([self.word2id(token)
+                                for token in tokens if token in self._tokens],
+                                dtype=np.uint32)
+                
+        else:
+            ret = np.zeros(len(tokens), dtype=np.uint32)
+            for k, token in enumerate(tokens):
+                try:
+                    ret[k] = self.word2id(token)
+                except KeyError:
+                    ret[k] = LARGEST_UINT32
+            return ret
+
+    def random_ids(self, num):
+        return np.random.randint(0, self._ntokens, size=num).astype(np.uint32)
 
 
 def iter_pairs(fin, vocab, batch_size=10, nsamples=2, window=5):


### PR DESCRIPTION
- Add a numerical gradient check
- Remove `seomoz/vocab` as a hard dependency.  It was only used in testing, so replaced with a simple implementation suitable for testing.
